### PR TITLE
Replace `stone.yml` with `stone.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Configuration file
 
 The configuration file is named `autobuild.yml`. It should be place on the same
-level as the package recipe file (e.g. `package.yml` or `stone.yml`).
+level as the package recipe file (e.g. `package.yml` or `stone.yaml`).
 
 Currently it's still very simple, with the specification as follows:
 ```yml

--- a/state/source_state.go
+++ b/state/source_state.go
@@ -136,7 +136,7 @@ func LoadSource(path string) (state *SourceState, err error) {
 		var pkg common.Package
 
 		ypkgFile := filepath.Join(pkgpath, "package.yml")
-		stoneFile := filepath.Join(pkgpath, "stone.yml")
+		stoneFile := filepath.Join(pkgpath, "stone.yaml")
 
 		if utils.PathExists(ypkgFile) {
 			pkg, err = common.ParsePackage(pkgpath)

--- a/stone/parse.go
+++ b/stone/parse.go
@@ -17,7 +17,7 @@ func ParsePackage(path string) (cpkg common.Package, err error) {
 		return ParseManifest(manifestPath)
 	}
 
-	stonePath := filepath.Join(path, "stone.yml")
+	stonePath := filepath.Join(path, "stone.yaml")
 	if !utils.PathExists(stonePath) {
 		return
 	}


### PR DESCRIPTION
Serpent OS recently switched to using the recommended YAML extension `.yaml` for YAML format files.